### PR TITLE
Disable SourceSqlInstance mandatory, disable SourceSqlInstance checks…

### DIFF
--- a/functions/image/New-DcnImage.ps1
+++ b/functions/image/New-DcnImage.ps1
@@ -341,7 +341,11 @@
         }
         else 
         {
-            $DatabaseCollection = $Database
+            $DatabaseCollection = 
+            @{
+                Name = $Database
+                Size = 1
+            };
         }
             
         if($BackupFilePath){


### PR DESCRIPTION
Workaround for last comment in #90 
Provides more flexibility, when dealing with existing bak files. 