### PR TITLE
Fixed Clone 

### DIFF
--- a/functions/clone/New-DcnClone.ps1
+++ b/functions/clone/New-DcnClone.ps1
@@ -384,7 +384,7 @@
             # Check if the clone vhd does not yet exist
             $clonePath = Join-PSFPath -Path $Destination -Child "$($CloneName).vhdx"
             if ($computer.IsLocalhost) {
-                if (Test-Path -Path "$($clonePath)" -Credential $DestinationCredential) {
+                if (Test-Path -Path $clonePath) {
                     Stop-PSFFunction -Message "Clone $CloneName already exists" -Target $accessPath -Continue
                 }
             }

--- a/functions/clone/Remove-DcnClone.ps1
+++ b/functions/clone/Remove-DcnClone.ps1
@@ -341,6 +341,9 @@
                             }
                         }
                     }
+                    else {
+                        Write-PSFMessage -Message "Clone '$($item.ImageLocation)' exists. Skipping 'Deleting clone from database'" -Level Warning
+                    }
                 }
             } # End for each group item
         } # End for each clone

--- a/functions/image/Remove-DcnImage.ps1
+++ b/functions/image/Remove-DcnImage.ps1
@@ -289,7 +289,7 @@
                         $imageVHDExists = Invoke-PSFCommand -ComputerName $item.HostName -ScriptBlock $command -Credential $Credential
                     }
                     
-                    if(-not $imageVHDExists){
+                    if (-not $imageVHDExists) {
                         if ($informationStore -eq 'SQL') {
                             # Remove the image from the database
                             try {
@@ -316,8 +316,8 @@
                             }
                         }
                     }
-                    else{
-                        
+                    else {
+                        Write-PSFMessage -Message "Image '$($item.ImageLocation)' exists. Skipping 'Removing image from database'" -Level Warning
                     }
                 }
             } # End for each item in group

--- a/functions/image/Remove-DcnImage.ps1
+++ b/functions/image/Remove-DcnImage.ps1
@@ -225,11 +225,10 @@
                 }
 
                 # Get the clones associated with the image
-                $results = @()
                 $results = Get-DcnClone -ImageID $item.ImageID
 
                 # Check the results
-                if ($results.Count -ge 1) {
+                if ($null -ne $results) {
                     # Loop through the results
                     foreach ($result in $results) {
                         if ($PSCmdlet.ShouldProcess($item.CloneID, "Removing clone $($result.CloneLocation) from $($result.HostName)")) {

--- a/functions/support/Test-DcnModule.ps1
+++ b/functions/support/Test-DcnModule.ps1
@@ -104,7 +104,9 @@ function Test-DcnModule {
                 'Microsoft Windows Server 2012 R2 Datacenter',
                 'Microsoft Windows Server 2016 Standard',
                 'Microsoft Windows Server 2016 Enterprise',
-                'Microsoft Windows Server 2016 Datacenter'
+                'Microsoft Windows Server 2016 Datacenter',
+                'Microsoft Windows Server 2019 Standard',
+                'Microsoft Windows Server 2019 Enterprise',
                 'Microsoft Windows Server 2019 Datacenter'
             )
 


### PR DESCRIPTION
# New-DcnClones
Removed `Credential` parameter from the Test-Path command as it threw an error because it is an invalid parameter.

# Remove-DcnClones
I added a check to ensure the Clone file has been deleted before removing the database record. The check has been added as there have been instances in testing where the database record has been deleted but the clone still exists which then prevents the image from being deleted as it is in use.

# Remove-DcnImages
Changed the logic [here](#diff-8000bdb9c952c1e41dbaeb5ccf41af418bda024020807c5bb7f139c44243b63eL232-R231) because when `Get-DcnClone` returns 1 clone the `$Result.Count` is null.

I also added a check to ensure the Image file has been deleted before removing the database record. This has been added as there have been instances where the image still exists but the database records have been removed and left an orphaned image file.

# Test-DcnModule
Added Microsoft Windows Server 2019 Standard and Enterprise to the list as they were missing.