### PR TITLE
Get-DcnImage: Use the stored credentials when querying the db if none are supplied on the command line.

### DIFF
--- a/functions/image/Get-DcnImage.ps1
+++ b/functions/image/Get-DcnImage.ps1
@@ -133,7 +133,7 @@
 
             try {
                 $results = @()
-                $results += Invoke-DbaQuery -SqlInstance $pdcSqlInstance -SqlCredential $DcnSqlCredential -Database $pdcDatabase -Query $query -As PSObject
+                $results += Invoke-DbaQuery -SqlInstance $pdcSqlInstance -SqlCredential $pdcCredential -Database $pdcDatabase -Query $query -As PSObject
             }
             catch {
                 Stop-PSFFunction -Message "Could retrieve images from database $pdcDatabase" -ErrorRecord $_ -Target $query


### PR DESCRIPTION
When working in an environment that doesn't have Windows auth set up, so SQL credentials are required, Get-DcnImage doesn't use the SQL user credentials saved during the call to Set-DcnConfiguration.
If you call Get-DcnImage without any other parameters, the current Windows user is used to authenticate, and if there isn't a domain/trusts set up, authentication will fail. This then cascades through to other commands that call Get-DcnImage without parameters.